### PR TITLE
Made KDBush generic so it can use types other than double/size_t for …

### DIFF
--- a/include/kdbush.hpp
+++ b/include/kdbush.hpp
@@ -1,64 +1,89 @@
+// https://github.com/mourner/kdbush.hpp
+
 #pragma once
 
 #include <algorithm>
 #include <cmath>
 #include <vector>
 
+template<class TFloat = double, class TIndex = std::size_t>
 class KDBush {
-
-    using size_t = std::size_t;
-
+    
 public:
-    KDBush(const std::vector<double> &coords_, const uint8_t nodeSize_ = 64)
-        : coords(coords_), nodeSize(nodeSize_) {
+
+    static const uint8_t defaultNodeSize = 64;
+    
+    KDBush(const std::vector<TFloat>& coords, const uint8_t nodeSize_ = defaultNodeSize)
+        : KDBush(std::begin(coords), std::end(coords), nodeSize_) {}
+
+    template<class TFloatIter>
+    KDBush(TFloatIter coordsBegin, TFloatIter coordsEnd, const uint8_t nodeSize_ = defaultNodeSize)
+        : coords(std::distance(coordsBegin, coordsEnd)), nodeSize(nodeSize_) {
+
+        std::copy(coordsBegin, coordsEnd, coords.data());
 
         const auto ids_size = coords.size() / 2;
         ids.reserve(ids_size);
-        for (size_t i = 0; i < ids_size; i++) ids.push_back(i);
+        for (size_t i = 0; i < ids_size; i++) ids.push_back(TIndex(i));
 
         sortKD(0, ids.size() - 1, 0);
     }
 
-    void range(const double minX,
-               const double minY,
-               const double maxX,
-               const double maxY,
-               std::vector<size_t> &result) {
-        range(minX, minY, maxX, maxY, result, 0, ids.size() - 1, 0);
+    void range(const TFloat minX,
+               const TFloat minY,
+               const TFloat maxX,
+               const TFloat maxY,
+               std::vector<TIndex> &result) {
+        range(minX, minY, maxX, maxY, [&result] (TIndex index) { result.push_back(index); });
     }
 
-    void within(const double qx, const double qy, const double r, std::vector<size_t> &result) {
-        within(qx, qy, r, result, 0, ids.size() - 1, 0);
+    template<class TPushBackIndex>
+    void range(const TFloat minX,
+               const TFloat minY,
+               const TFloat maxX,
+               const TFloat maxY,
+               const TPushBackIndex& push_back_index) {
+        range(minX, minY, maxX, maxY, push_back_index, 0, ids.size() - 1, 0);
+    }
+
+    void within(const TFloat qx, const TFloat qy, const TFloat r, std::vector<TIndex>& result) {
+        within(qx, qy, r, [&result] (TIndex index) { result.push_back(index); });
+    }
+
+    template<class TPushBackIndex>
+    void within(const TFloat qx, const TFloat qy, const TFloat r, const TPushBackIndex& push_back_index) {
+        within(qx, qy, r, push_back_index, 0, ids.size() - 1, 0);
     }
 
 private:
     uint8_t nodeSize;
-    std::vector<size_t> ids;
-    std::vector<double> coords;
+    std::vector<TIndex> ids;
+    std::vector<TFloat> coords;
 
-    void range(const double minX,
-               const double minY,
-               const double maxX,
-               const double maxY,
-               std::vector<size_t> &result,
-               const size_t left,
-               const size_t right,
+    template<class TPushBackIndex>
+    void range(const TFloat minX,
+               const TFloat minY,
+               const TFloat maxX,
+               const TFloat maxY,
+               const TPushBackIndex& push_back_index,
+               const TIndex left,
+               const TIndex right,
                const uint8_t axis) {
 
         if (right - left <= nodeSize) {
             for (auto i = left; i <= right; i++) {
-                const double x = coords[2 * i];
-                const double y = coords[2 * i + 1];
-                if (x >= minX && x <= maxX && y >= minY && y <= maxY) result.push_back(ids[i]);
+                const TFloat x = coords[2 * i];
+                const TFloat y = coords[2 * i + 1];
+                if (x >= minX && x <= maxX && y >= minY && y <= maxY) push_back_index(ids[i]);
             }
             return;
         }
 
-        const size_t m = (left + right) >> 1;
-        const double x = coords[2 * m];
-        const double y = coords[2 * m + 1];
+        const TIndex m = (left + right) >> 1;
+        const TFloat x = coords[2 * m];
+        const TFloat y = coords[2 * m + 1];
 
-        if (x >= minX && x <= maxX && y >= minY && y <= maxY) result.push_back(ids[m]);
+        if (x >= minX && x <= maxX && y >= minY && y <= maxY) push_back_index(ids[m]);
 
         if (axis == 0 ? minX <= x : minY <= y)
             range(minX, minY, maxX, maxY, result, left, m - 1, (axis + 1) % 2);
@@ -67,62 +92,63 @@ private:
             range(minX, minY, maxX, maxY, result, m + 1, right, (axis + 1) % 2);
     }
 
-    void within(const double qx,
-                const double qy,
-                const double r,
-                std::vector<size_t> &result,
-                const size_t left,
-                const size_t right,
+    template<class TPushBackIndex>    
+    void within(const TFloat qx,
+                const TFloat qy,
+                const TFloat r,
+                const TPushBackIndex& push_back_index,
+                const TIndex left,
+                const TIndex right,
                 const uint8_t axis) {
 
-        const double r2 = r * r;
+        const TFloat r2 = r * r;
 
         if (right - left <= nodeSize) {
             for (auto i = left; i <= right; i++) {
                 if (sqDist(coords[2 * i], coords[2 * i + 1], qx, qy) <= r2)
-                    result.push_back(ids[i]);
+                    push_back_index(ids[i]);
             }
             return;
         }
 
-        const size_t m = (left + right) >> 1;
-        const double x = coords[2 * m];
-        const double y = coords[2 * m + 1];
+        const TIndex m = (left + right) >> 1;
+        const TFloat x = coords[2 * m];
+        const TFloat y = coords[2 * m + 1];
 
-        if (sqDist(x, y, qx, qy) <= r2) result.push_back(ids[m]);
+        if (sqDist(x, y, qx, qy) <= r2) push_back_index(ids[m]);
 
         if (axis == 0 ? qx - r <= x : qy - r <= y)
-            within(qx, qy, r, result, left, m - 1, (axis + 1) % 2);
+            within(qx, qy, r, push_back_index, left, m - 1, (axis + 1) % 2);
 
         if (axis == 0 ? qx + r >= x : qy + r >= y)
-            within(qx, qy, r, result, m + 1, right, (axis + 1) % 2);
+            within(qx, qy, r, push_back_index, m + 1, right, (axis + 1) % 2);
     }
 
-    void sortKD(const size_t left, const size_t right, const uint8_t axis) {
+    void sortKD(const TIndex left, const TIndex right, const uint8_t axis) {
         if (right - left <= nodeSize) return;
-        const size_t m = (left + right) >> 1;
+        const TIndex m = (left + right) >> 1;
         select(m, left, right, axis);
         sortKD(left, m - 1, (axis + 1) % 2);
         sortKD(m + 1, right, (axis + 1) % 2);
     }
 
-    void select(const size_t k, size_t left, size_t right, const uint8_t axis) {
+    void select(const TIndex k, TIndex left, TIndex right, const uint8_t axis) {
 
         while (right > left) {
             if (right - left > 600) {
-                const size_t n = right - left + 1;
-                const size_t m = k - left + 1;
-                const double z = log(n);
-                const double s = 0.5 * exp(2 * z / 3);
-                const double sd = 0.5 * sqrt(z * s * (n - s) / n) * (2 * m < n ? -1 : 1);
-                const size_t newLeft = std::max(left, size_t(k - m * s / n + sd));
-                const size_t newRight = std::min(right, size_t(k + (n - m) * s / n + sd));
+                const TIndex n = right - left + 1;
+                const TIndex m = k - left + 1;
+                const TFloat z = log(n);
+                const TFloat s = 0.5 * exp(2 * z / 3);
+                const TFloat sd = 0.5 * sqrt(z * s * (n - s) / n) * (2 * m < n ? -1 : 1);
+                const TIndex newLeft = std::max(left, TIndex(k - m * s / n + sd));
+                const TIndex newRight = std::min(right, TIndex(k + (n - m) * s / n + sd));
                 select(k, newLeft, newRight, axis);
             }
 
-            const double t = coords[2 * k + axis];
-            size_t i = left;
-            size_t j = right;
+            const TFloat t = coords[2 * k + axis];
+            TIndex i = left;
+            TIndex j = right;
 
             swapItem(left, k);
             if (coords[2 * right + axis] > t) swapItem(left, right);
@@ -147,15 +173,15 @@ private:
         }
     }
 
-    void swapItem(const size_t i, const size_t j) {
+    void swapItem(const TIndex i, const TIndex j) {
         std::iter_swap(ids.begin() + i, ids.begin() + j);
         std::iter_swap(coords.begin() + 2 * i, coords.begin() + 2 * j);
         std::iter_swap(coords.begin() + 2 * i + 1, coords.begin() + 2 * j + 1);
     }
 
-    double sqDist(const double ax, const double ay, const double bx, const double by) {
-        const double dx = ax - bx;
-        const double dy = ay - by;
+    TFloat sqDist(const TFloat ax, const TFloat ay, const TFloat bx, const TFloat by) {
+        const TFloat dx = ax - bx;
+        const TFloat dy = ay - by;
         return dx * dx + dy * dy;
     }
 };


### PR DESCRIPTION
…coordinates and indices respectively.

I'm using KDBush in a game project, and my input coordinates are single precision floats, and my indices are of type int16_t.

At first I simply copied my data into a std::vector<double> and casted indices from size_t back to int16_t, but making the whole thing generic to start was easy enough, so I figured I give it a try. I also added a generic constructor for the input source (since my coordinates don't live in an std::vector, but I can pass in begin and end iterators).

With the default parameters still being double and size_t, as well as the overloads that still provide the old interface, this version should be drop-in, except for the fact that you have to add "<>" to the typename (to use the default template types).

I suppose one option is to rename KDBush to KDBushT<>, and then provide a default typedef KDBush that uses the defaults. Then it would be completely drop-in.

At any rate, while the change is fairly superficial in nature, I do realize that it affects lots of code, and you may not like the aesthetics or otherwise consequences of this change. So I don't necessarily expect you to accept this pull request, it's more of a food for thought thing.

Thanks,

Jaap Suter

p.s. Thanks for adding a license so quickly, really awesome!
