### PR TITLE
Fix crashes when using an empty index

### DIFF
--- a/include/kdbush.hpp
+++ b/include/kdbush.hpp
@@ -94,6 +94,8 @@ private:
                const TIndex right,
                const std::uint8_t axis) {
 
+        if (points.empty()) return;
+
         if (right - left <= nodeSize) {
             for (auto i = left; i <= right; i++) {
                 const TNumber x = std::get<0>(points[i]);
@@ -124,6 +126,8 @@ private:
                 const TIndex left,
                 const TIndex right,
                 const std::uint8_t axis) {
+
+        if (points.empty()) return;
 
         const TNumber r2 = r * r;
 

--- a/test.cpp
+++ b/test.cpp
@@ -45,6 +45,12 @@ static void testRadius() {
 static void testEmpty() {
     auto emptyPoints = std::vector<TPoint>{};
     kdbush::KDBush<TPoint> index(emptyPoints);
+    // test no crash when using empty index
+    TIds result;
+    index.within(50, 50, 20, [&result](const auto id) { result.push_back(id); });
+    assert(result.empty());
+    index.range(20, 30, 50, 70, [&result](const auto id) { result.push_back(id); });
+    assert(result.empty());
 }
 
 int main() {


### PR DESCRIPTION
While 1e22d35  fixes a crash which occurs when creating an empty index, trying to perform a search using an empty index still results in a crash.